### PR TITLE
Do not error if multiple synopsis exist in SYNOPSIS section. And enabled...

### DIFF
--- a/t/comment.t
+++ b/t/comment.t
@@ -1,0 +1,8 @@
+use Test::Synopsis;
+
+BEGIN {
+    use Test::More tests => 1;
+    use Test::Synopsis;
+}
+
+synopsis_ok('t/lib/Comment.pm');

--- a/t/lib/Comment.pm
+++ b/t/lib/Comment.pm
@@ -1,0 +1,41 @@
+package Test::Synopsis::__Comment;
+
+use strict;
+use warnings;
+
+use version; $VERSION = qw/0.0.1/;
+
+1;
+
+__END__
+
+=head1 NAME
+
+Comment - for test
+
+
+=head1 VERSION
+
+This document describes Test::Synopsis::__Comment
+
+
+=head1 SYNOPSIS
+
+    use strict;
+    use warnings;
+
+=for test_synopsis_comment_begin
+
+THIS IS COMMENT
+
+=for test_synopsis_comment_end
+
+AND THIS IS ALSO COMMENT
+
+
+    print "Hello, test!";
+
+
+=head1 DESCRIPTION
+
+Foo Bar.

--- a/t/lib/MultiplePod.pm
+++ b/t/lib/MultiplePod.pm
@@ -1,0 +1,39 @@
+package Test::Synopsis::__MultiplePod;
+
+use strict;
+use warnings;
+
+use version; $VERSION = qw/0.0.1/;
+
+1;
+
+__END__
+
+=head1 NAME
+
+MultiplePod - for test
+
+
+=head1 VERSION
+
+This document describes Test::Synopsis::__MultiplePod
+
+
+=head1 SYNOPSIS
+
+    use strict;
+    use warnings;
+
+    print "Hello, test!";
+
+=for test_synopsis_divide
+
+    use strict;
+    use warnings;
+
+    print "Goodbye, test!";
+
+
+=head1 DESCRIPTION
+
+Foo Bar.

--- a/t/lib/MultipleWithComment.pm
+++ b/t/lib/MultipleWithComment.pm
@@ -1,0 +1,44 @@
+package Test::Synopsis::__MultipleWithComment;
+
+use strict;
+use warnings;
+
+use version; $VERSION = qw/0.0.1/;
+
+1;
+
+__END__
+
+=head1 NAME
+
+MultipleWithComment - for test
+
+
+=head1 VERSION
+
+This document describes Test::Synopsis::__MultipleWithComment
+
+
+=head1 SYNOPSIS
+
+    use strict;
+    use warnings;
+
+    print "Hello, test!";
+
+=for test_synopsis_comment_begin
+
+THIS IS COMMENT
+
+=for test_synopsis_comment_end
+=for test_synopsis_divide
+
+    use strict;
+    use warnings;
+
+    print "Goodbye, test!";
+
+
+=head1 DESCRIPTION
+
+Foo Bar.

--- a/t/multiple_pod.t
+++ b/t/multiple_pod.t
@@ -1,0 +1,8 @@
+use Test::Synopsis;
+
+BEGIN {
+    use Test::More tests => 2;
+    use Test::Synopsis;
+}
+
+synopsis_ok('t/lib/MultiplePod.pm');

--- a/t/multiple_with_comment.t
+++ b/t/multiple_with_comment.t
@@ -1,0 +1,8 @@
+use Test::Synopsis;
+
+BEGIN {
+    use Test::More tests => 2;
+    use Test::Synopsis;
+}
+
+synopsis_ok('t/lib/MultipleWithComment.pm');


### PR DESCRIPTION
SYNOPSIS のセクションに複数のsynopsis が存在するとテストがfail してしまう( 例: http://search.cpan.org/~jettero/Statistics-Basic-1.6607/lib/Statistics/Basic/Correlation.pod )ので、"=for test_synopsis_divide" という文でsynopsis を分割して、それぞれを独立のsynopsis として扱えるように改造しました。

また、SYNOPSIS セクション中にコード以外の文が入っているとこれまたテストがfail してしまうので、「"=for test_synopsis_comment_begin" と"=for test_synopsis_comment_end" で括られた部分」と「インデントを付けずに記述された文」についてはコメントとして扱い、eval で評価しないように書き換えました。
