### PR TITLE
Fixes the problem when SYNOPSIS contains __END__

### DIFF
--- a/lib/Test/Synopsis.pm
+++ b/lib/Test/Synopsis.pm
@@ -54,6 +54,9 @@ sub extract_synopsis {
     my $code = ($content =~ m/^=head1\s+SYNOPSIS(.+?)^=head1/ms)[0];
     my $line = ($` || '') =~ tr/\n/\n/;
 
+    # don't want __END__ blocks in SYNOPSIS chopping our '}' in wrapper sub
+    $code =~ s/(?=[;\s]*__END__\s*$)/}\n/m;
+
     return $code, $line-1, ($content =~ m/^=for\s+test_synopsis\s+(.+?)^=/msg);
 }
 
@@ -142,6 +145,11 @@ Test::Synopsis will find these C<=for> blocks and these statements are
 prepended before your SYNOPSIS code when being evaluated, so those
 variable name errors will go away, without adding unnecessary bits in
 SYNOPSIS which might confuse users.
+
+=head1 CAVEATS
+
+This module will not check code past the C<__END__> token, if one is
+present in the SYNOPSIS code.
 
 =head1 AUTHOR
 

--- a/t/end-in-pod.t
+++ b/t/end-in-pod.t
@@ -1,0 +1,5 @@
+use Test::More tests => 1;
+use Test::Synopsis;
+synopsis_ok("t/lib/ENDInPod.pm");
+
+

--- a/t/lib/ENDInPod.pm
+++ b/t/lib/ENDInPod.pm
@@ -1,0 +1,30 @@
+package Test::Synopsis::__TestBait_ENDinPod;
+
+# Dummy module used during testing of Test::Synopsis. Needs to be in the lib/
+# dir of the Test-Synopsis distribution to Test::Synopsis can find it.
+#
+# This module does not has an __END__ in the synopsis code; it shouldn't
+# break Test::Synopsis
+
+use strict;
+use warnings;
+
+our $VERSION = '0.05';
+
+1;
+
+=pod
+
+=head1 SYNOPSIS
+
+    print "Foos!\n";
+    
+    __END__
+    
+    BLARGHS!
+
+=head1 DESCRIPTION
+
+bleh
+
+=cut


### PR DESCRIPTION
This fixes the issue with `__END__` present in SYNOPSIS and provides the corresponding tests.

The problem is when the SYNOPSIS code contains **END**, e.g. this:

``` perl
=head1 SYNOPSIS

    print "BLAH!";

    __END__

=head1 DESCRIPTION
```

The test dies with:

```
#   Failed test 'lib/WWW/Lipsum.pm'
#   at /home/zoffix/perl5/lib/perl5/Test/Synopsis.pm line 18.
# Missing right curly or square bracket at lib/WWW/Lipsum.pm line 119, at end of line
# syntax error at lib/WWW/Lipsum.pm line 119, at EOF
# Looks like you failed 1 test of 1.
```
