### PR TITLE
Fixes RT#84863: Unindented text isn't code; needs to be ignored

### DIFF
--- a/lib/Test/Synopsis.pm
+++ b/lib/Test/Synopsis.pm
@@ -54,8 +54,12 @@ sub extract_synopsis {
     my $code = ($content =~ m/^=head1\s+SYNOPSIS(.+?)^=head1/ms)[0];
     my $line = ($` || '') =~ tr/\n/\n/;
 
+    # unindented text isn't code; get rid of it. Leave newlines where
+    # they are, so the reported line numbers of the errors are correct.
+    $code =~ s/^\S+.+$//mg;
+
     # don't want __END__ blocks in SYNOPSIS chopping our '}' in wrapper sub
-    $code =~ s/(?=[;\s]*__END__\s*$)/}\n/m;
+    $code =~ s/(?=__END__\s*$)/}\n/m;
 
     return $code, $line-1, ($content =~ m/^=for\s+test_synopsis\s+(.+?)^=/msg);
 }

--- a/t/lib/PlainTextInPod.pm
+++ b/t/lib/PlainTextInPod.pm
@@ -1,0 +1,34 @@
+package Test::Synopsis::__TestBait_PlainTextInPod;
+
+# Dummy module used during testing of Test::Synopsis. Needs to be in the lib/
+# dir of the Test-Synopsis distribution to Test::Synopsis can find it.
+#
+# This module has plain text in the middle of the SYNOPSIS code; we should
+# ignore it
+
+use strict;
+use warnings;
+
+our $VERSION = '0.05';
+
+1;
+
+=pod
+
+=head1 SYNOPSIS
+
+Print some foos:
+
+    print "Foos!\n";
+    
+Blarg away:
+    
+    BLARGHS();
+    
+MOAR BLARGHS!
+
+=head1 DESCRIPTION
+
+bleh
+
+=cut

--- a/t/plain-text-in-pod.t
+++ b/t/plain-text-in-pod.t
@@ -1,0 +1,5 @@
+use Test::More tests => 1;
+use Test::Synopsis;
+synopsis_ok("t/lib/PlainTextInPod.pm");
+
+


### PR DESCRIPTION
This fixes RT#84863: https://rt.cpan.org/Ticket/Display.html?id=84863
A test testing this feature is also included.

---

Fixed issue:

Say, we have this SYNOPSIS:

``` perl
=head1 SYNOPSIS

Print some foos:

    print "Foos!\n";

And then print some bars:

   print "Bars\n";

=cut
```

Only the `print` statements will be rendered as code in the POD, but this module currently assumes the plain text portions are part of the code. This pull request fixes the issue.
