### PR TITLE
Full rewrite

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -32,6 +32,7 @@ contributor = Mike Doherty <doherty@cpan.org>
 contributor = Patrice Clement <monsieurp@gentoo.org>
 contributor = Greg Sabino Mullane <turnstep@cpan.org>
 contributor = Zoffix Znet <zoffix@cpan.org>
+contributor = Olivier Mengué <dolmen@cpan.org>
 
 [Git::NextVersion]
 first_version = 0.07

--- a/t/01-fail-if-SYNOPSIS-has-errors.t
+++ b/t/01-fail-if-SYNOPSIS-has-errors.t
@@ -12,7 +12,7 @@ test_diag(q{  Failed test 't/lib/BrokenSYNOPSIS01.pm'},
             ? ' (did you forget to declare "my $x"?)'
             : ''
         )
-     . q{ at t/lib/BrokenSYNOPSIS01.pm line 20.},
+     . q{ at t/lib/BrokenSYNOPSIS01.pm line 18.},
 );
 synopsis_ok("t/lib/BrokenSYNOPSIS01.pm");
 test_test("synopsis fail works");

--- a/t/02-END-token-errors.t
+++ b/t/02-END-token-errors.t
@@ -12,7 +12,7 @@ test_diag(q{  Failed test 't/lib/ENDInPodWithError.pm'},
         ? ' (did you forget to declare "my $x"?)'
         : ''
     )
-    . q{ at t/lib/ENDInPodWithError.pm line 30.},
+    . q{ at t/lib/ENDInPodWithError.pm line 24.},
 );
 synopsis_ok("t/lib/ENDInPodWithError.pm");
 test_test("synopsis fail works");

--- a/t/05-multi-chunks-clash.t
+++ b/t/05-multi-chunks-clash.t
@@ -7,7 +7,7 @@ not ok 2 - t/lib/TestMultipleChunks.pm (section 2)');
 
 test_diag(q{  Failed test 't/lib/TestMultipleChunks.pm (section 2)'
 #   at t/05-multi-chunks-clash.t line 12.
-# Bareword "bob" not allowed while "strict subs" in use at t/lib/TestMultipleChunks.pm line 31.});
+# Bareword "bob" not allowed while "strict subs" in use at t/lib/TestMultipleChunks.pm line 29.});
 
 synopsis_ok("t/lib/TestMultipleChunks.pm");
 test_test("synopsis with multiple chunks fails");

--- a/t/12-DATA-token-errors.t
+++ b/t/12-DATA-token-errors.t
@@ -12,7 +12,7 @@ test_diag(q{  Failed test 't/lib/Test12DATAInPodWithError.pm'},
         ? ' (did you forget to declare "my $x"?)'
         : ''
     )
-    . q{ at t/lib/Test12DATAInPodWithError.pm line 28.},
+    . q{ at t/lib/Test12DATAInPodWithError.pm line 24.},
 );
 synopsis_ok("t/lib/Test12DATAInPodWithError.pm");
 test_test("synopsis fail works");


### PR DESCRIPTION
The compile errors were not reported on the right line. Even the test suite was broken (someone cheated to make the tests pass?).
As the parsing code was too much complex for the task, I rewrote it using Pod::Simple. The code is much shorter (reduced by 1/4; 50 lines removed).
The generated code is fixed to report errors on the right line. Now bugs in "=for test_synopsis" will also be reported with the correct line number.

I'm a candidate to be a co-maintainer on the module.