### PR TITLE
Require Pod::Simple 3.09

### DIFF
--- a/lib/Test/Synopsis.pm
+++ b/lib/Test/Synopsis.pm
@@ -92,6 +92,7 @@ sub _extract_synopsis
 package
   Test::Synopsis::Parser; # on new line to avoid indexing
 
+use Pod::Simple 3.09;
 use parent 'Pod::Simple';
 
 sub new


### PR DESCRIPTION
This is the version that added the strip_verbatim_indent method.