### PR TITLE
Whitelist Mengué for spell checker

### DIFF
--- a/lib/Test/Synopsis.pm
+++ b/lib/Test/Synopsis.pm
@@ -168,6 +168,7 @@ __END__
 
 =for stopwords Goro blogged Znet Zoffix DOHERTY Doherty
   KRYDE Ryde ZOFFIX Gr nauer Grünauer pm HEREDOC HEREDOCs DROLSKY
+  Mengué
 
 =for test_synopsis $main::for_checked=1
 


### PR DESCRIPTION
After upgrading Test-Spelling from 0.22 to 0.23 a new error emrged:

    not ok 1 - POD spelling for lib/Test/Synopsis.pm
    #   Failed test 'POD spelling for lib/Test/Synopsis.pm'
    #   at xt/author/pod-spell.t line 11.
    # Errors:
    #     Mengu
    #
    # All incorrect words, by number of occurrences:
    #      1: Mengu
    # Looks like you failed 1 test of 1.

This patch adds Mengué to the stopwords.